### PR TITLE
fix(orderForm): changed 'item' property to 'order_item' in 'menuItemC…

### DIFF
--- a/application/src/components/order-form/orderForm.js
+++ b/application/src/components/order-form/orderForm.js
@@ -20,7 +20,7 @@ class OrderForm extends Component {
     }
 
     menuItemChosen(event) {
-        this.setState({ item: event.target.value });
+        this.setState({ order_item: event.target.value });
     }
 
     menuQuantityChosen(event) {
@@ -41,9 +41,9 @@ class OrderForm extends Component {
                 'Content-Type': 'application/json'
             }
         })
-        .then(res => res.json())
-        .then(response => console.log("Success", JSON.stringify(response)))
-        .catch(error => console.error(error));
+            .then(res => res.json())
+            .then(response => console.log("Success", JSON.stringify(response)))
+            .catch(error => console.error(error));
     }
 
     render() {
@@ -52,8 +52,8 @@ class OrderForm extends Component {
                 <div className="form-wrapper">
                     <form>
                         <label className="form-label">I'd like to order...</label><br />
-                        <select 
-                            value={this.state.order_item} 
+                        <select
+                            value={this.state.order_item}
                             onChange={(event) => this.menuItemChosen(event)}
                             className="menu-select"
                         >


### PR DESCRIPTION
**Intentional Bug**
Order form submit doesn't work.

**Changes made to fix the issue**
The property used by `menuItemChosen` method has been updated to match with the property provided by the `OrderForm` component. 
- Property used before changes: `item`
- Property used after changes: `order-item`


**Steps taken to fix the issue**
1. Identify the specific property set by `submitOrder` method to handle the Order submission event in the component
2. Check to see if that specific property is being correctly passed down to `menuItemChosen` method. 
3. Step 2 led to the finding of the issue. The `menuItemChosen` method was attempting to set an incorrect property `item` that did not match with the property set by submitOrder method.  

Closes Shift3#14