### PR TITLE
fix(authReducer): typo fixed in order to return email for the LOGIN case

### DIFF
--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
**Feature Request**
Retrieve user from Redux and include in Order form

**Changes made to implement this feature**
fixed the type in action payload's property from "login" to "email"

**Steps taken to implement this feature**
1. Familiarized.myself with Redux first by reading the documentation
2. The typo itself was easy to find because "login" property did not exist and it needed to be replaced with the correct property "email"

Closes Shift3#17