### PR TITLE
fix(viewOrders): fixed formatting of time to include leading 0

### DIFF
--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -12,7 +12,7 @@ class ViewOrders extends Component {
         fetch(`${SERVER_IP}/api/current-orders`)
             .then(response => response.json())
             .then(response => {
-                if(response.success) {
+                if (response.success) {
                     this.setState({ orders: response.orders });
                 } else {
                     console.log('Error getting orders');
@@ -25,7 +25,7 @@ class ViewOrders extends Component {
             <Template>
                 <div className="container-fluid">
                     {this.state.orders.map(order => {
-                        const createdDate = new Date(order.createdAt);
+                        const createdDate = new Date(order.createdAt).toTimeString().substr(0, 8);
                         return (
                             <div className="row view-order-container" key={order._id}>
                                 <div className="col-md-4 view-order-left-col p-3">
@@ -33,13 +33,13 @@ class ViewOrders extends Component {
                                     <p>Ordered by: {order.ordered_by || ''}</p>
                                 </div>
                                 <div className="col-md-4 d-flex view-order-middle-col">
-                                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                                    <p>Order placed at {createdDate}</p>
                                     <p>Quantity: {order.quantity}</p>
-                                 </div>
-                                 <div className="col-md-4 view-order-right-col">
-                                     <button className="btn btn-success">Edit</button>
-                                     <button className="btn btn-danger">Delete</button>
-                                 </div>
+                                </div>
+                                <div className="col-md-4 view-order-right-col">
+                                    <button className="btn btn-success">Edit</button>
+                                    <button className="btn btn-danger">Delete</button>
+                                </div>
                             </div>
                         );
                     })}


### PR DESCRIPTION
**Bug: Order Time does not format time correctly**

**Changes made to fix this issue**
`createdDate` property in the render method has been changed to include the correct formatting of the Date timeString

**Steps taken to solve this issue**
The conventional approach to solving this issue would be creating a separate function that formats OrderTime based on the conditions we provide and we can call this function. 
However, a much simpler approach would be to just call `.toTimeString()` on the Date object and use the JavaScript `substr()` method with parameters(0,8) to format time `hh:mm:ss` format.
`.split()` method can also be used to format the string but `substr()` is relatively faster.
Source:[jsperf.com/split-vs-substring](url)
Closes Shift3#30